### PR TITLE
Change references of "ClientId" to "Audience".

### DIFF
--- a/B2C-WebApi/Startup.cs
+++ b/B2C-WebApi/Startup.cs
@@ -43,7 +43,7 @@ namespace B2CWebApi
                 .AddJwtBearer(jwtOptions =>
                 {
                   jwtOptions.Authority = $"https://login.microsoftonline.com/tfp/{Configuration["AzureAdB2C:Tenant"]}/{Configuration["AzureAdB2C:Policy"]}/v2.0/";
-                  jwtOptions.Audience = Configuration["AzureAdB2C:ClientId"];
+                  jwtOptions.Audience = Configuration["AzureAdB2C:Audience"];
                   jwtOptions.Events = new JwtBearerEvents
                   {
                     OnAuthenticationFailed = AuthenticationFailed

--- a/B2C-WebApi/appsettings.json
+++ b/B2C-WebApi/appsettings.json
@@ -1,12 +1,12 @@
 {
   "AzureAdB2C": {
     "Tenant": "fabrikamb2c.onmicrosoft.com",
-    "ClientId": "25eef6e4-c905-4a07-8eb4-0d08d5df8b3f",
+    "Audience": "25eef6e4-c905-4a07-8eb4-0d08d5df8b3f",
     "Policy": "b2c_1_susi",
 
     "ScopeRead": "demo.read",
     "ScopeWrite": "demo.write"
-    },
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Your web API registration should include the following information:
 1. Open the solution in Visual Studio.
 1. Open the `appsettings.json` file.
 1. Find the assignment for `Tenant` and replace the value with your tenant name.
-1. Find the assignment for `ClientID` and replace the value with the Application ID from Step 4.
+1. Find the assignment for `Audience` and replace the value with the Application ID from Step 4.
 1. Find the assignment for `Policy` and replace the value with the name of the policy from Step 3.
 
 ### Step 6: Run the sample
@@ -76,7 +76,7 @@ As it is standard practice for ASP.NET Core Web APIs, the token validation funct
   .AddJwtBearer(jwtOptions =>
   {
     jwtOptions.Authority = $"https://login.microsoftonline.com/tfp/{Configuration["AzureAdB2C:Tenant"]}/{Configuration["AzureAdB2C:Policy"]}/v2.0/";
-    jwtOptions.Audience = Configuration["AzureAdB2C:ClientId"];
+    jwtOptions.Audience = Configuration["AzureAdB2C:Audience"];
     jwtOptions.Events = new JwtBearerEvents
     {
       OnAuthenticationFailed = AuthenticationFailed


### PR DESCRIPTION
When running the sample against my own AD B2C tenant, I encountered the following error.

    `AuthenticationFailed: IDX10214: Audience validation failed. Audiences: 'abc'. Did not match: validationParameters.ValidAudience: 'xyz' or validationParameters.ValidAudiences:  'null'.`

The "ClientId" in the appsettings.json was misleading since it is really an "Audience" setting. I understood the difference after reading [https://stackoverflow.com/questions/28418360/jwt-json-web-token-audience-aud-versus-client-id-whats-the-difference](https://stackoverflow.com/questions/28418360/jwt-json-web-token-audience-aud-versus-client-id-whats-the-difference), and created this pull request to help clarify the difference for anyone using this sample.