### PR TITLE
(Azure CXP) Added steps to README 

### DIFF
--- a/B2C-WebApi/Views/Home/Index.cshtml
+++ b/B2C-WebApi/Views/Home/Index.cshtml
@@ -5,7 +5,7 @@
 <body>
 Your API will now be available via http://localhost:5000/api/Values
 
-Obtain a token by signing in <a href="https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_SUSI&client_id=9595a991-a717-4669-9af0-d58420ad733a&nonce=defaultNonce&redirect_uri=https%3A%2F%2Fjwt.ms&scope=https%3A%2F%2Ffabrikamb2c.onmicrosoft.com%2Fdemoapi%2Fdemo.read&response_type=token&prompt=login" target="_blank">here.</a>
+Obtain a token by signing in <a href="https://login.microsoftonline.com/<your-B2C-Tenant-Name>/oauth2/v2.0/authorize?p=<B2C-Policy-Name>&client_id=<Client-ID>&nonce=defaultNonce&redirect_uri=https%3A%2F%2Fjwt.ms&scope=<Your-Scope>&response_type=token&prompt=login" target="_blank">here.</a>
 <br/>
 <br/>
 Try it out via curl using the comand below.

--- a/B2C-WebApi/appsettings.json
+++ b/B2C-WebApi/appsettings.json
@@ -1,12 +1,11 @@
 {
   "AzureAdB2C": {
-    "Tenant": "fabrikamb2c.onmicrosoft.com",
-    "ClientId": "25eef6e4-c905-4a07-8eb4-0d08d5df8b3f",
-    "Policy": "b2c_1_susi",
-
-    "ScopeRead": "demo.read",
-    "ScopeWrite": "demo.write"
-    },
+    "Tenant": "<Your-B2C-Tenant>",
+    "ClientId": "<Client-ID>",
+    "Policy": "<Your-B2C-Policy>",
+    "ScopeRead": "hello.read", // insert your read scope here, if you followed the aad b2c docs for hello.read/write, you can use hello.read/write accordingly. 
+    "ScopeWrite": "hello.write"
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You will need to [register your Web API with Azure AD B2C](https://docs.microsof
 Your web API registration should include the following information:
 
 - Enable the **Web App/Web API** setting for your application.
-- Enter any **Reply URL**, as indicated previously, because the web API only does token validation and does not obtain tokens, this isn't really required. For example `https://myapi`.
+- Enter any **Reply URL**, as indicated previously, because the web API only does token validation and does not obtain token. To get this sample to work, you will want to use the reply url : `https://jwt.ms`.
 - Make sure you also provide a **AppID URI**, for example `demoapi`, this is used to construct the scopes that are configured in you single page application's code.
 - (Optional) Once you're app is created, open the app's **Published Scopes** blade and add any extra scopes you want.
 - Copy the **Application ID** generated for your application and **Published Scopes values**, so you can input them in your application's code.
@@ -56,6 +56,7 @@ Your web API registration should include the following information:
 1. Find the assignment for `Tenant` and replace the value with your tenant name.
 1. Find the assignment for `ClientID` and replace the value with the Application ID from Step 4.
 1. Find the assignment for `Policy` and replace the value with the name of the policy from Step 3.
+1. Modify the `Index.cshtml` file's url with your b2c tenant, policy name, client id, and scope.
 
 ### Step 6: Run the sample
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,22 @@ Your web API registration should include the following information:
 
 1. Open the solution in Visual Studio.
 1. Open the `appsettings.json` file.
-1. Find the assignment for `Tenant` and replace the value with your tenant name.
-1. Find the assignment for `ClientID` and replace the value with the Application ID from Step 4.
-1. Find the assignment for `Policy` and replace the value with the name of the policy from Step 3.
-1. Modify the `Index.cshtml` file's url with your b2c tenant, policy name, client id, and scope.
+
+(1) Find the assignment for `Tenant` and replace the value with your tenant name.
+  
+(2) Find the assignment for `ClientID` and replace the value with the Application ID from Step 4.
+  
+(3) Find the assignment for `Policy` and replace the value with the name of the policy from Step 3.
+  
+3. Open the `Index.cshtml` file in the views folder. Find the url in this file at location : https://github.com/FrankHu-MSFT/active-directory-b2c-dotnetcore-webapi/blob/master/B2C-WebApi/Views/Home/Index.cshtml#L8
+
+(1) Find the assignment for `Tenant` and replace the value with your tenant name.
+  
+(2) Find the assignment for `ClientID` and replace the value with the Application ID from Step 4.
+  
+(3) Find the assignment for `Policy` and replace the value with the name of the policy from Step 3.
+  
+(4) Find the assignment for `Scope` and replace the value with the name of the policy from Step 3.
 
 ### Step 6: Run the sample
 


### PR DESCRIPTION
The index.cshtml needs to be modified, otherwise it redirects to the wrong link. Also added clearer insertions for client id, tenant, etc...