### PR TITLE
Remove YAML front-matter from deprecated sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
----
-page_type: sample
-languages:
-  - csharp
-products:
-  - azure
-  - azure-active-directory
-  - aspnet
-  - dotnet
-description: "This sample shows how to build a web API with Azure AD B2C using the ASP.Net Core JWT Bearer middleware."
----
-
 # An ASP.NET Core 2.0 web API with Azure AD B2C
 
 This sample shows how to build a web API with Azure AD B2C using the ASP.Net Core JWT Bearer middleware.  It assumes you have some familiarity with Azure AD B2C.  If you'd like to learn all that B2C has to offer, start with our documentation at [aka.ms/aadb2c](http://aka.ms/aadb2c). 


### PR DESCRIPTION
To de-list a sample from the docs.microsoft.com [Samples Browser](https://docs.microsoft.com/samples/), the repo webhook needs to be disabled (done) and the YAML front-matter defining the sample metadata needs to be removed from the README (this PR).

When the daily publish job next runs, the sample should then be removed from the browser.

> NOTE: I've temporarily unarchived this repo. Once this is merged we can archive again.

Cc: @jmprieur @jennyf19 